### PR TITLE
refactor(execute): offload synchronous execution to thread pool

### DIFF
--- a/lso/routes/execute.py
+++ b/lso/routes/execute.py
@@ -1,5 +1,6 @@
 """FastAPI route for running arbitrary executables."""
 
+import asyncio
 import uuid
 from pathlib import Path
 from typing import Annotated
@@ -48,5 +49,5 @@ async def run_executable_endpoint(params: ExecutableRunParams) -> ExecutableRunR
         return ExecutableRunResponse(job_id=job_id)
 
     job_id = uuid.uuid4()
-    result = run_executable_sync(str(params.executable_name), params.args)
+    result = await asyncio.to_thread(run_executable_sync, str(params.executable_name), params.args)
     return ExecutableRunResponse(job_id=job_id, result=result)


### PR DESCRIPTION
Offload blocking sync execution to a thread using asyncio.to_thread  aligns with FastAPI best practices of keeping the event loop responsive
