### PR TITLE
Prevent playbook runs from orphaning workflows on pexpect timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # Ansible configuration
 ANSIBLE_PLAYBOOKS_ROOT_DIR="/path/to/ansible/playbooks"
 ANSIBLE_ROLES_PATH="/app/lso/ansible_roles"  # Set specific Ansible roles path
+ANSIBLE_PEXPECT_TIMEOUT_SEC=300  # Idle read timeout for Ansible runner's pexpect child before it raises TIMEOUT
 
 # Executor configuration
 EXECUTOR="threadpool"  # Options: "threadpool", "celery"

--- a/lso/config.py
+++ b/lso/config.py
@@ -44,6 +44,9 @@ class Config(BaseSettings):
         CELERY_RESULT_EXPIRES (int, optional): Celery result expiration timeout, in seconds.
         WORKER_QUEUE_NAME (str, optional): Celery worker queue name.
         EXECUTABLE_TIMEOUT_SEC (int, optional): Timeout period for an executable, in seconds.
+        ANSIBLE_PEXPECT_TIMEOUT_SEC (int, optional): Idle read timeout, in seconds, that Ansible runner's pexpect
+            child process waits for output before raising a ``TIMEOUT``. Raising this prevents long-running or
+            momentarily silent tasks (e.g. a slow network device commit) from crashing the playbook run.
 
     """
 
@@ -58,6 +61,7 @@ class Config(BaseSettings):
     CELERY_RESULT_EXPIRES: int = 3600
     WORKER_QUEUE_NAME: str | None = None
     EXECUTABLE_TIMEOUT_SEC: int = 300
+    ANSIBLE_PEXPECT_TIMEOUT_SEC: int = 300
 
 
 settings = Config()

--- a/lso/tasks.py
+++ b/lso/tasks.py
@@ -137,13 +137,35 @@ def run_playbook_proc_task(
     """
     msg = f"playbook_path: {playbook_path}, callback: {callback}"
     logger.info(msg)
-    run(
-        playbook=playbook_path,
-        inventory=inventory,
-        extravars=extra_vars,
-        event_handler=playbook_event_handler_factory(progress, progress_is_incremental=progress_is_incremental),
-        finished_callback=playbook_finished_handler_factory(callback, job_id),
-    )
+    try:
+        run(
+            playbook=playbook_path,
+            inventory=inventory,
+            extravars=extra_vars,
+            event_handler=playbook_event_handler_factory(progress, progress_is_incremental=progress_is_incremental),
+            finished_callback=playbook_finished_handler_factory(callback, job_id),
+            settings={"pexpect_timeout": settings.ANSIBLE_PEXPECT_TIMEOUT_SEC, "idle_timeout": None},
+        )
+    except Exception as e:
+        # Ansible runner may raise (e.g. a pexpect ``TIMEOUT``) before ``finished_callback`` fires. Without an
+        # explicit failure callback, the calling system would wait indefinitely for a result that never arrives.
+        logger.exception("Playbook run crashed before the finished callback could fire")
+        if callback:
+            failure_payload = {
+                "status": "failed",
+                "job_id": job_id,
+                "output": [f"LSO worker error: {e!r}"],
+                "return_code": 1,
+            }
+            try:
+                response = requests.post(str(callback), json=failure_payload, timeout=settings.REQUEST_TIMEOUT_SEC)
+                response.raise_for_status()
+            except HTTPError as callback_error:
+                raise CallbackFailedError(
+                    status_code=callback_error.response.status_code,
+                    detail=f"{callback_error.response.reason} for url: {callback_error.request.url}",
+                ) from callback_error
+        raise
 
 
 @celery.task(name=RUN_EXECUTABLE)  # type: ignore[untyped-decorator]

--- a/test/test_playbook.py
+++ b/test/test_playbook.py
@@ -11,10 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 import responses
+from pydantic import HttpUrl
 from starlette import status
 
+from lso.config import settings
 from lso.playbook import run_playbook
 
 TEST_CALLBACK_URL = "http://localhost/callback"
@@ -35,3 +39,44 @@ def test_playbook_execution() -> None:
 
     responses.assert_call_count(TEST_CALLBACK_URL, 1)
     assert callback.status == status.HTTP_200_OK
+
+
+@responses.activate
+def test_playbook_crash_posts_failure_callback() -> None:
+    """If Ansible runner crashes before the finished callback fires, a failure status must still be posted."""
+    callback = responses.post(TEST_CALLBACK_URL)
+
+    with patch("lso.tasks.run", side_effect=RuntimeError("boom")), pytest.raises(RuntimeError, match="boom"):
+        run_playbook(
+            playbook_path=Path(__file__).parent / "test-playbook.yaml",
+            extra_vars={},
+            inventory="127.0.0.1",
+            callback=HttpUrl(TEST_CALLBACK_URL),
+            progress=HttpUrl(TEST_PROGRESS_URL),
+            progress_is_incremental=True,
+        )
+
+    responses.assert_call_count(TEST_CALLBACK_URL, 1)
+    assert callback.status == status.HTTP_200_OK
+    request_body = callback.calls[0].request.body
+    assert request_body is not None
+    body_text = request_body.decode() if isinstance(request_body, bytes) else request_body
+    assert '"status": "failed"' in body_text
+
+
+@responses.activate
+def test_playbook_uses_configured_pexpect_timeout() -> None:
+    """The configured pexpect timeout must be passed through to Ansible runner."""
+    with patch("lso.tasks.run") as mock_run:
+        run_playbook(
+            playbook_path=Path(__file__).parent / "test-playbook.yaml",
+            extra_vars={},
+            inventory="127.0.0.1",
+            callback=None,
+            progress=None,
+            progress_is_incremental=True,
+        )
+
+    passed_settings = mock_run.call_args.kwargs["settings"]
+    assert passed_settings["pexpect_timeout"] == settings.ANSIBLE_PEXPECT_TIMEOUT_SEC
+    assert passed_settings["idle_timeout"] is None


### PR DESCRIPTION
## Problem

A workflow in Workflow Orchestrator got permanently stuck in **`Running Ansible playbook` / `awaiting_callback`**.

Root cause traced from the LSO worker logs: during a playbook run, Ansible runner's **pexpect child process hit its idle read timeout** (30s in the affected environment) on a task that produced no output while a network device processed a slow netconf commit/diff. pexpect raised `TIMEOUT`, which propagated out of `ansible_runner.run()` and **crashed the Celery task**. Because the crash happened before `finished_callback` fired, **no result was ever POSTed back**, so the orchestrator waited indefinitely.

Device-side logs confirmed the router handled the netconf transaction cleanly and quickly — the stall was purely on the runner/pexpect side, not the device.

## Fix

- Add `ANSIBLE_PEXPECT_TIMEOUT_SEC` (default `300`) and pass it to Ansible runner via `settings={"pexpect_timeout": ..., "idle_timeout": None}`, so a brief gap in task output no longer aborts the whole run.
- Wrap `run()` so that if it still raises for any reason, a `"failed"` status is POSTed to the callback before re-raising. This guarantees a run can **never** silently orphan a waiting workflow again.
- Document the new setting in `.env.example`.
- Add tests for the failure-callback path and the timeout pass-through.

## Verification

- `ruff check .` / `ruff format --check .` clean
- `ty check .` passes (exit 0)
- `pytest` — 32 passed
- Change was hot-patched onto the affected UAT workers and confirmed to load (`pexpect_timeout=300`) before preparing this PR.