### PR TITLE
Prevent playbook runs from orphaning workflows on runner crash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Ansible configuration
 ANSIBLE_PLAYBOOKS_ROOT_DIR="/path/to/ansible/playbooks"
 ANSIBLE_ROLES_PATH="/app/lso/ansible_roles"  # Set specific Ansible roles path
+# Idle/read timeout (seconds) for the ansible-runner output pipe, passed through as pexpect_timeout. A larger value
+# tolerates slow-but-healthy device operations and normal gaps between tasks without aborting a successful run.
+ANSIBLE_PLAYBOOK_TIMEOUT_SEC=300
 
 # Executor configuration
 EXECUTOR="threadpool"  # Options: "threadpool", "celery"

--- a/docs/playbooks/callback.md
+++ b/docs/playbooks/callback.md
@@ -5,4 +5,4 @@ to this URL.
 
 ## Code Documentation
 
-::: lso.tasks.playbook_finished_handler_factory
+::: lso.tasks.PlaybookFinishedHandler

--- a/lso/config.py
+++ b/lso/config.py
@@ -44,6 +44,10 @@ class Config(BaseSettings):
         CELERY_RESULT_EXPIRES (int, optional): Celery result expiration timeout, in seconds.
         WORKER_QUEUE_NAME (str, optional): Celery worker queue name.
         EXECUTABLE_TIMEOUT_SEC (int, optional): Timeout period for an executable, in seconds.
+        ANSIBLE_PLAYBOOK_TIMEOUT_SEC (int, optional): Idle/read timeout, in seconds, for the ansible-runner output
+            pipe. This is passed to ansible-runner as its ``pexpect_timeout`` so that a transient gap in playbook
+            output (e.g. a slow-but-healthy device operation) does not abort an otherwise-successful run. Defaults to
+            a large value to tolerate such gaps; the underlying job is still bounded by the run itself.
 
     """
 
@@ -58,6 +62,7 @@ class Config(BaseSettings):
     CELERY_RESULT_EXPIRES: int = 3600
     WORKER_QUEUE_NAME: str | None = None
     EXECUTABLE_TIMEOUT_SEC: int = 300
+    ANSIBLE_PLAYBOOK_TIMEOUT_SEC: int = 300
 
 
 settings = Config()

--- a/lso/config.py
+++ b/lso/config.py
@@ -44,8 +44,8 @@ class Config(BaseSettings):
         CELERY_RESULT_EXPIRES (int, optional): Celery result expiration timeout, in seconds.
         WORKER_QUEUE_NAME (str, optional): Celery worker queue name.
         EXECUTABLE_TIMEOUT_SEC (int, optional): Timeout period for an executable, in seconds.
-        ANSIBLE_PLAYBOOK_TIMEOUT_SEC (int, optional): Idle/read timeout, in seconds, for the ansible-runner output
-            pipe. This is passed to ansible-runner as its ``pexpect_timeout`` so that a transient gap in playbook
+        ANSIBLE_PLAYBOOK_TIMEOUT_SEC (int, optional): Idle/read timeout, in seconds, for the `ansible-runner` output
+            pipe. This is passed to `ansible-runner` as its `pexpect_timeout` so that a transient gap in playbook
             output (e.g. a slow-but-healthy device operation) does not abort an otherwise-successful run. Defaults to
             a large value to tolerate such gaps; the underlying job is still bounded by the run itself.
 

--- a/lso/tasks.py
+++ b/lso/tasks.py
@@ -112,6 +112,34 @@ def playbook_finished_handler_factory(callback: str | None, job_id: str) -> Call
     return None
 
 
+def _post_playbook_failure_callback(callback: str | None, job_id: str, exc: BaseException) -> None:
+    """Notify the orchestrator that a playbook run crashed before it could report its own result.
+
+    Mirrors the payload shape of `playbook_finished_handler_factory` with a failed status so the workflow
+    can transition out of `awaiting_callback` instead of hanging. Any error while delivering this callback is
+    logged and swallowed, so it never masks the original exception that is being re-raised by the caller.
+
+    Args:
+        callback (str, optional): The callback URL that the Ansible runner should report to. No-op if not set.
+        job_id (str): The job ID of this playbook run, used for reporting.
+        exc (BaseException): The exception that escaped the runner, included in the callback output for diagnostics.
+
+    """
+    if not callback:
+        return
+
+    payload = {
+        "status": "failed",
+        "job_id": job_id,
+        "output": [f"Ansible playbook run failed: {exc}"],
+        "return_code": -1,
+    }
+    try:
+        requests.post(str(callback), json=payload, timeout=settings.REQUEST_TIMEOUT_SEC)
+    except requests.RequestException:
+        logger.exception("Failed to POST failure callback to %s for job_id=%s", callback, job_id)
+
+
 @celery.task(name=RUN_PLAYBOOK)  # type: ignore[untyped-decorator]
 def run_playbook_proc_task(
     job_id: str,
@@ -137,13 +165,35 @@ def run_playbook_proc_task(
     """
     msg = f"playbook_path: {playbook_path}, callback: {callback}"
     logger.info(msg)
-    run(
-        playbook=playbook_path,
-        inventory=inventory,
-        extravars=extra_vars,
-        event_handler=playbook_event_handler_factory(progress, progress_is_incremental=progress_is_incremental),
-        finished_callback=playbook_finished_handler_factory(callback, job_id),
-    )
+
+    finished_handler = playbook_finished_handler_factory(callback, job_id)
+    result_reported = False
+
+    def _finished_callback(runner: Runner) -> None:
+        # Mark that the run reached completion and its result callback was attempted, so the crash safety net
+        # below does not fire a second, conflicting callback if delivering that result then fails.
+        nonlocal result_reported
+        result_reported = True
+        if finished_handler is not None:
+            finished_handler(runner)
+
+    try:
+        run(
+            playbook=playbook_path,
+            inventory=inventory,
+            extravars=extra_vars,
+            event_handler=playbook_event_handler_factory(progress, progress_is_incremental=progress_is_incremental),
+            finished_callback=_finished_callback if finished_handler else None,
+            settings={"pexpect_timeout": settings.ANSIBLE_PLAYBOOK_TIMEOUT_SEC},
+        )
+    except Exception as exc:
+        # Safety net: if the runner crashes before its finished_callback fires (e.g. a pexpect read timeout),
+        # no result is ever POSTed and the orchestrator's workflow orphans in `awaiting_callback`. Notify the
+        # orchestrator of the failure before re-raising so the workflow can never hang indefinitely.
+        logger.exception("Ansible playbook run for job_id=%s crashed", job_id)
+        if not result_reported:
+            _post_playbook_failure_callback(callback, job_id, exc)
+        raise
 
 
 @celery.task(name=RUN_EXECUTABLE)  # type: ignore[untyped-decorator]

--- a/lso/tasks.py
+++ b/lso/tasks.py
@@ -73,33 +73,50 @@ def playbook_event_handler_factory(
     return None
 
 
-def playbook_finished_handler_factory(callback: str | None, job_id: str) -> Callable[[Runner], None] | None:
-    """Once Ansible runner is finished, it will call back to the specified URL in the original request.
+class PlaybookFinishedHandler:
+    """Report a finished Ansible playbook run to the callback URL from the original request.
+
+    An instance is passed to `ansible-runner` as its `finished_callback` and invoked once when the run shuts down.
+    It records in `reported` whether that report was made, so the caller can tell the run reached completion and
+    avoid sending a second, conflicting callback if the run instead crashed before finishing.
 
     Args:
-        callback (str, optional): The callback URL that the Ansible runner should report to.
+        callback (str, optional): The callback URL that the Ansible runner should report to. When not set, the
+            handler is a no-op (nothing is POSTed).
         job_id (str): The job ID of this playbook run, used for reporting.
 
-    Returns:
-        A handler method that sends one request to the callback URL.
+    Attributes:
+        reported (bool): `True` once the handler has run, i.e. the playbook finished and its result callback was
+            attempted (regardless of whether delivering it then succeeded).
 
     Raises:
         CallbackFailedError: If the callback to the external system has failed.
 
     """
 
-    def _playbook_finished_handler(runner: Runner) -> None:
-        playbook_output = runner.stdout.read().split("\n")
-        playbook_output = [line for line in playbook_output if line.strip()]
+    def __init__(self, callback: str | None, job_id: str) -> None:
+        """Store the callback URL and job ID to report on when the playbook run finishes."""
+        self._callback = callback
+        self._job_id = job_id
+        self.reported = False
 
+    def __call__(self, runner: Runner) -> None:
+        """Send one request with the playbook result to the callback URL."""
+        # Record completion before attempting delivery, so a failure while POSTing does not let the caller's
+        # crash safety net fire a second callback for the same job.
+        self.reported = True
+        if not self._callback:
+            return
+
+        playbook_output = [line for line in runner.stdout.read().split("\n") if line.strip()]
         payload = {
             "status": runner.status,
-            "job_id": job_id,
+            "job_id": self._job_id,
             "output": playbook_output,
             "return_code": int(str(runner.rc)),
         }
 
-        response = requests.post(str(callback), json=payload, timeout=settings.REQUEST_TIMEOUT_SEC)
+        response = requests.post(str(self._callback), json=payload, timeout=settings.REQUEST_TIMEOUT_SEC)
         try:
             response.raise_for_status()
         except HTTPError as e:
@@ -107,15 +124,11 @@ def playbook_finished_handler_factory(callback: str | None, job_id: str) -> Call
                 status_code=e.response.status_code, detail=f"{e.response.reason} for url: {e.request.url}"
             ) from e
 
-    if callback:
-        return _playbook_finished_handler
-    return None
-
 
 def _post_playbook_failure_callback(callback: str | None, job_id: str, exc: BaseException) -> None:
     """Notify the orchestrator that a playbook run crashed before it could report its own result.
 
-    Mirrors the payload shape of `playbook_finished_handler_factory` with a failed status so the workflow
+    Mirrors the payload shape of `PlaybookFinishedHandler` with a failed status so the workflow
     can transition out of `awaiting_callback` instead of hanging. Any error while delivering this callback is
     logged and swallowed, so it never masks the original exception that is being re-raised by the caller.
 
@@ -166,32 +179,23 @@ def run_playbook_proc_task(
     msg = f"playbook_path: {playbook_path}, callback: {callback}"
     logger.info(msg)
 
-    finished_handler = playbook_finished_handler_factory(callback, job_id)
-    result_reported = False
-
-    def _finished_callback(runner: Runner) -> None:
-        # Mark that the run reached completion and its result callback was attempted, so the crash safety net
-        # below does not fire a second, conflicting callback if delivering that result then fails.
-        nonlocal result_reported
-        result_reported = True
-        if finished_handler is not None:
-            finished_handler(runner)
-
+    finished_handler = PlaybookFinishedHandler(callback, job_id)
     try:
         run(
             playbook=playbook_path,
             inventory=inventory,
             extravars=extra_vars,
             event_handler=playbook_event_handler_factory(progress, progress_is_incremental=progress_is_incremental),
-            finished_callback=_finished_callback if finished_handler else None,
+            finished_callback=finished_handler,
             settings={"pexpect_timeout": settings.ANSIBLE_PLAYBOOK_TIMEOUT_SEC},
         )
     except Exception as exc:
-        # Safety net: if the runner crashes before its finished_callback fires (e.g. a pexpect read timeout),
-        # no result is ever POSTed and the orchestrator's workflow orphans in `awaiting_callback`. Notify the
-        # orchestrator of the failure before re-raising so the workflow can never hang indefinitely.
+        # Safety net: if the runner crashes before finished_handler runs (e.g. a pexpect read timeout), no result
+        # is ever POSTed and the orchestrator's workflow orphans in `awaiting_callback`. Notify the orchestrator
+        # of the failure before re-raising so the workflow can never hang indefinitely. `finished_handler.reported`
+        # guards against a second, conflicting callback when the run completed but delivering its result failed.
         logger.exception("Ansible playbook run for job_id=%s crashed", job_id)
-        if not result_reported:
+        if not finished_handler.reported:
             _post_playbook_failure_callback(callback, job_id, exc)
         raise
 

--- a/test/test_playbook.py
+++ b/test/test_playbook.py
@@ -10,12 +10,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from pathlib import Path
+from typing import Any
 
+import pytest
 import responses
 from starlette import status
 
+from lso.config import settings
 from lso.playbook import run_playbook
+from lso.tasks import run_playbook_proc_task
 
 TEST_CALLBACK_URL = "http://localhost/callback"
 TEST_PROGRESS_URL = "http://localhost/progress"
@@ -35,3 +40,101 @@ def test_playbook_execution() -> None:
 
     responses.assert_call_count(TEST_CALLBACK_URL, 1)
     assert callback.status == status.HTTP_200_OK
+
+
+def test_run_playbook_passes_configured_timeout_to_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The configured playbook timeout is passed to ansible_runner.run as the idle/read timeout."""
+    configured_timeout = 123
+    captured: dict[str, Any] = {}
+
+    def fake_run(*_args: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("lso.tasks.run", fake_run)
+    monkeypatch.setattr(settings, "ANSIBLE_PLAYBOOK_TIMEOUT_SEC", configured_timeout)
+
+    run_playbook_proc_task(
+        job_id="job-1",
+        playbook_path="/path/to/playbook.yaml",
+        extra_vars={},
+        inventory="127.0.0.1",
+        callback=None,
+        progress=None,
+        progress_is_incremental=True,
+    )
+
+    assert captured["settings"]["pexpect_timeout"] == configured_timeout
+
+
+@responses.activate
+def test_run_playbook_crash_posts_failure_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ansible_runner.run raises, a failed-status callback is POSTed before the exception is re-raised.
+
+    This is the safety net that prevents a crashed run from orphaning a workflow in ``awaiting_callback``.
+    """
+
+    crash_message = "TIMEOUT(<pexpect.pty_spawn.spawn ...>)"
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError(crash_message)
+
+    monkeypatch.setattr("lso.tasks.run", fake_run)
+    callback = responses.post(TEST_CALLBACK_URL)
+
+    with pytest.raises(RuntimeError, match="TIMEOUT"):
+        run_playbook_proc_task(
+            job_id="job-xyz",
+            playbook_path="/path/to/playbook.yaml",
+            extra_vars={},
+            inventory="127.0.0.1",
+            callback=TEST_CALLBACK_URL,
+            progress=None,
+            progress_is_incremental=True,
+        )
+
+    responses.assert_call_count(TEST_CALLBACK_URL, 1)
+    body = json.loads(callback.calls[0].request.body)
+    assert body["status"] == "failed"
+    assert body["job_id"] == "job-xyz"
+    assert body["return_code"] != 0
+
+
+@responses.activate
+def test_run_playbook_result_callback_failure_not_double_posted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure delivering the result callback must not trigger a second, spurious failure callback.
+
+    Once the run completes and its result callback has been attempted, the crash safety net must stay out of the
+    way — otherwise a transient orchestrator hiccup would produce two conflicting callbacks for one job.
+    """
+    from io import StringIO  # noqa: PLC0415
+
+    from lso.tasks import CallbackFailedError  # noqa: PLC0415
+
+    class _Runner:
+        status = "successful"
+        rc = 0
+
+        def __init__(self) -> None:
+            self.stdout = StringIO("some output")
+
+    def fake_run(*_args: Any, **kwargs: Any) -> None:
+        # Simulate a completed run invoking its finished_callback, which POSTs the result callback.
+        kwargs["finished_callback"](_Runner())
+
+    monkeypatch.setattr("lso.tasks.run", fake_run)
+    # Orchestrator rejects the result callback, so the finished handler raises CallbackFailedError.
+    responses.post(TEST_CALLBACK_URL, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    with pytest.raises(CallbackFailedError):
+        run_playbook_proc_task(
+            job_id="job-2",
+            playbook_path="/path/to/playbook.yaml",
+            extra_vars={},
+            inventory="127.0.0.1",
+            callback=TEST_CALLBACK_URL,
+            progress=None,
+            progress_is_incremental=True,
+        )
+
+    # Exactly one POST — the result callback. No spurious second failure callback.
+    responses.assert_call_count(TEST_CALLBACK_URL, 1)


### PR DESCRIPTION
A brief pause in Ansible runner output could trip a pexpect read timeout and crash the Celery task before its `finished_callback` fired, leaving the workflow stuck in `awaiting_callback` with no result ever POSTed back.

## Changes

- Make the ansible-runner idle/read timeout configurable via `ANSIBLE_PLAYBOOK_TIMEOUT_SEC` (default 300s), passed to `run()` as `pexpect_timeout`, so transient output gaps no longer abort a healthy run.
- POST a `failed`-status callback when any exception escapes the runner, before re-raising, so a crashed run can never orphan a workflow. A completion guard avoids a second callback when result delivery itself fails.
- Document the new setting in `.env.example`.

## Testing

Added tests for the configured timeout reaching the runner and for a crash producing a failure callback. Full suite passes; `ruff` and `ty` clean.
