### PR TITLE
Register Celery tasks when the worker starts

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0
+current_version = 4.1.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -11,7 +11,7 @@ COPY ./ansible-galaxy-requirements.yaml ./ansible-galaxy-requirements.yaml
 RUN apk add --update --no-cache gcc libc-dev libffi-dev openssh tini
 
 # Install the LSO python package, and additional requirements
-RUN pip install orchestrator-lso=="4.1.0"
+RUN pip install orchestrator-lso=="4.1.1"
 RUN pip install -r requirements.txt
 
 # Install required Ansible Galaxy roles and collections

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,5 +20,5 @@ To install LSO in your `uv` virtual environment, use:
 
 ```sh
 uv init
-uv add orchestrator-lso==4.1.0
+uv add orchestrator-lso==4.1.1
 ```

--- a/lso/__init__.py
+++ b/lso/__init__.py
@@ -13,4 +13,4 @@
 
 """LSO, an API for remotely running Ansible playbooks."""
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"

--- a/lso/worker.py
+++ b/lso/worker.py
@@ -43,6 +43,12 @@ if settings.WORKER_QUEUE_NAME:
         RUN_EXECUTABLE: {"queue": settings.WORKER_QUEUE_NAME},
     }
 
+# Ensure the task modules are imported so their ``@celery.task`` decorators register the tasks. The worker is started
+# with ``-A lso.worker``, which does not otherwise import ``lso.tasks``; without this, the worker boots with an empty
+# task registry and rejects every incoming task with "Received unregistered task". ``autodiscover_tasks`` is used
+# instead of a top-level import to avoid the circular import between ``lso.worker`` and ``lso.tasks``.
+celery.autodiscover_tasks(["lso"], related_name="tasks", force=True)
+
 
 @worker_shutting_down.connect  # type: ignore[untyped-decorator]
 def worker_shutting_down_handler(sig, how, exitcode, **kwargs) -> None:  # type: ignore[no-untyped-def] # noqa: ARG001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestrator-lso"
-version = "4.1.0"
+version = "4.1.1"
 description = "LSO, an API for remotely running Ansible playbooks."
 readme = "README.md"
 license = "Apache-2.0"

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -1,0 +1,25 @@
+# Copyright 2026 GÉANT Vereniging.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lso.worker import RUN_EXECUTABLE, RUN_PLAYBOOK, celery
+
+
+def test_worker_registers_tasks() -> None:
+    """The Celery app must have the playbook and executable tasks registered.
+
+    The worker is started with ``-A lso.worker``, so ``lso.worker`` is solely responsible for ensuring the task
+    modules are imported. If this regresses, the worker boots with an empty registry and rejects every incoming task
+    with "Received unregistered task", silently stalling any workflow that dispatches to it.
+    """
+    assert RUN_PLAYBOOK in celery.tasks
+    assert RUN_EXECUTABLE in celery.tasks

--- a/uv.lock
+++ b/uv.lock
@@ -873,7 +873,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-lso"
-version = "4.1.0"
+version = "4.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
## Problem

Freshly deployed LSO workers reject every dispatched playbook/executable task and discard it, so playbooks never run and the calling workflow stalls with no execution output and no callback:

```
ERROR/MainProcess] Received unregistered task of type 'lso.tasks.run_playbook_proc_task'.
The message has been ignored and discarded.
...
KeyError: 'lso.tasks.run_playbook_proc_task'
```

The Celery banner shows an empty `[tasks]` list — the worker boots with **zero** registered tasks.

## Root cause

The worker is launched with `celery -A lso.worker`, but `lso/worker.py` creates the Celery app **without importing `lso.tasks`** and without any autodiscovery. The `@celery.task` decorators only run when `lso.tasks` is imported, and only `lso/playbook.py` / `lso/execute.py` import it — neither of which the worker process loads at startup. So the task registry is empty.

(A top-level `import lso.tasks` in `worker.py` is not possible because `lso.tasks` imports `celery` from `lso.worker`, which would be a circular import.)

## Fix

- Add `celery.autodiscover_tasks(["lso"])` after the app is configured. Autodiscovery defers the import to worker readiness, avoiding the circular import while ensuring the task modules are loaded and their decorators register the tasks.
- Add a regression test asserting both `run_playbook_proc_task` and `run_executable_proc_task` are present in `celery.tasks`.

## Verification

- Reproduced on a live deployment: workers booted with an empty registry and rejected real workflow tasks (`edge_port.yaml`, `l3_core_service.yaml`).
- Confirmed that importing `lso.tasks` alongside the app registers both tasks.
- `ruff check` / `ruff format --check` clean, `ty check .` passes (exit 0), `pytest` — 34 passed.