### PR TITLE
chore: bump version to 4.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestrator-lso"
-version = "4.1.1"
+version = "4.2.0"
 description = "LSO, an API for remotely running Ansible playbooks."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-lso"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
Bump version to `4.2.0` for the next PyPI release.

Minor bump (new backwards-compatible functionality) since v4.1.1:
- New self-healing Celery broker config options (8 new `CELERY_*` settings) with safe defaults
- Celery broker self-heal after Redis switch-over
- Dependency updates (fastapi, redis, uvicorn, pydantic-settings, httpx2)
- Vale doc-linting CI fix

`uv.lock` regenerated; `uv build` verified locally producing 4.2.0 artifacts.

Once merged, create the GitHub Release `v4.2.0` to trigger the PyPI publish workflow.