### PR TITLE
fix: bound broker socket reads to survive silent Redis connection loss

### DIFF
--- a/lso/config.py
+++ b/lso/config.py
@@ -50,9 +50,18 @@ class Config(BaseSettings):
         CELERY_REDIS_SOCKET_KEEPALIVE (bool, optional): Enable TCP keep-alive on the Redis broker connection.
         CELERY_REDIS_HEALTH_CHECK_INTERVAL (int, optional): Seconds between Redis broker connection health checks.
         CELERY_REDIS_RETRY_ON_TIMEOUT (bool, optional): Retry a Redis command that timed out instead of dropping it.
-        CELERY_REDIS_SOCKET_TIMEOUT (float, optional): Timeout, in seconds, for Redis result-store socket operations.
+        CELERY_REDIS_SOCKET_TIMEOUT (float, optional): Timeout, in seconds, for Redis socket operations on the
+            broker and result-store connections, so a socket that died without an RST fails instead of blocking
+            the worker forever.
         CELERY_REDIS_SOCKET_CONNECT_TIMEOUT (float, optional): Timeout, in seconds, for establishing a Redis
-            result-store socket connection.
+            broker or result-store socket connection.
+        CELERY_REDIS_SOCKET_KEEPALIVE_IDLE (int, optional): Seconds a Redis connection is idle before TCP
+            keep-alive probing starts (``TCP_KEEPIDLE``). The kernel default of 7200 seconds is far too slow to
+            detect a broker connection that died silently during a switch-over.
+        CELERY_REDIS_SOCKET_KEEPALIVE_INTERVAL (int, optional): Seconds between TCP keep-alive probes on an idle
+            Redis connection (``TCP_KEEPINTVL``).
+        CELERY_REDIS_SOCKET_KEEPALIVE_COUNT (int, optional): Failed TCP keep-alive probes after which the kernel
+            declares a Redis connection dead (``TCP_KEEPCNT``).
         WORKER_QUEUE_NAME (str, optional): Celery worker queue name.
         EXECUTABLE_TIMEOUT_SEC (int, optional): Timeout period for an executable, in seconds.
         ANSIBLE_PLAYBOOK_TIMEOUT_SEC (int, optional): Idle/read timeout, in seconds, for the `ansible-runner` output
@@ -79,6 +88,9 @@ class Config(BaseSettings):
     CELERY_REDIS_RETRY_ON_TIMEOUT: bool = True
     CELERY_REDIS_SOCKET_TIMEOUT: float = 30.0
     CELERY_REDIS_SOCKET_CONNECT_TIMEOUT: float = 10.0
+    CELERY_REDIS_SOCKET_KEEPALIVE_IDLE: int = 30
+    CELERY_REDIS_SOCKET_KEEPALIVE_INTERVAL: int = 10
+    CELERY_REDIS_SOCKET_KEEPALIVE_COUNT: int = 3
     WORKER_QUEUE_NAME: str | None = None
     EXECUTABLE_TIMEOUT_SEC: int = 300
     ANSIBLE_PLAYBOOK_TIMEOUT_SEC: int = 300

--- a/lso/config.py
+++ b/lso/config.py
@@ -51,8 +51,8 @@ class Config(BaseSettings):
         CELERY_REDIS_HEALTH_CHECK_INTERVAL (int, optional): Seconds between Redis broker connection health checks.
         CELERY_REDIS_RETRY_ON_TIMEOUT (bool, optional): Retry a Redis command that timed out instead of dropping it.
         CELERY_REDIS_SOCKET_TIMEOUT (float, optional): Timeout, in seconds, for Redis socket operations on the
-            broker and result-store connections, so a socket that died without an RST fails instead of blocking
-            the worker forever.
+            broker and result-store connections, so a socket that died without a TCP reset packet reaching
+            the client fails instead of blocking the worker forever.
         CELERY_REDIS_SOCKET_CONNECT_TIMEOUT (float, optional): Timeout, in seconds, for establishing a Redis
             broker or result-store socket connection.
         CELERY_REDIS_SOCKET_KEEPALIVE_IDLE (int, optional): Seconds a Redis connection is idle before TCP

--- a/lso/worker.py
+++ b/lso/worker.py
@@ -40,9 +40,10 @@ celery = Celery(
 # them.
 #
 # ``socket_timeout`` and the TCP keep-alive timing overrides are essential: a switch-over kills
-# established connections without an RST reaching the client, so an unbounded ``recv()`` on such
-# a half-open socket blocks the consumer's restart sequence forever (kernel keep-alive only fires
-# after 2 hours by default) and none of the retry settings ever get a chance to run.
+# established connections without a TCP reset packet reaching the client, so an unbounded
+# ``recv()`` on such a half-open socket blocks the consumer's restart sequence forever (kernel
+# keep-alive only fires after 2 hours by default) and none of the retry settings ever get a
+# chance to run.
 #
 # ``TCP_KEEPIDLE`` is Linux-specific; macOS (local development) exposes ``TCP_KEEPALIVE`` with the
 # same semantics, so the mapping is built from whichever constants the platform provides.

--- a/lso/worker.py
+++ b/lso/worker.py
@@ -13,6 +13,8 @@
 
 """Module that sets up LSO as a Celery worker."""
 
+import socket
+
 from celery import Celery
 from celery.signals import worker_shutting_down
 
@@ -36,10 +38,31 @@ celery = Celery(
 # below. None of this ties LSO to Redis: with another broker or result store (for example
 # RabbitMQ or ``rpc://``) these options are simply ignored by the transport that does not know
 # them.
+#
+# ``socket_timeout`` and the TCP keep-alive timing overrides are essential: a switch-over kills
+# established connections without an RST reaching the client, so an unbounded ``recv()`` on such
+# a half-open socket blocks the consumer's restart sequence forever (kernel keep-alive only fires
+# after 2 hours by default) and none of the retry settings ever get a chance to run.
+#
+# ``TCP_KEEPIDLE`` is Linux-specific; macOS (local development) exposes ``TCP_KEEPALIVE`` with the
+# same semantics, so the mapping is built from whichever constants the platform provides.
+_socket_keepalive_options: dict[int, int] = {}
+if hasattr(socket, "TCP_KEEPIDLE"):
+    _socket_keepalive_options[socket.TCP_KEEPIDLE] = settings.CELERY_REDIS_SOCKET_KEEPALIVE_IDLE
+elif hasattr(socket, "TCP_KEEPALIVE"):
+    _socket_keepalive_options[socket.TCP_KEEPALIVE] = settings.CELERY_REDIS_SOCKET_KEEPALIVE_IDLE
+if hasattr(socket, "TCP_KEEPINTVL"):
+    _socket_keepalive_options[socket.TCP_KEEPINTVL] = settings.CELERY_REDIS_SOCKET_KEEPALIVE_INTERVAL
+if hasattr(socket, "TCP_KEEPCNT"):
+    _socket_keepalive_options[socket.TCP_KEEPCNT] = settings.CELERY_REDIS_SOCKET_KEEPALIVE_COUNT
+
 redis_transport_options = {
     "socket_keepalive": settings.CELERY_REDIS_SOCKET_KEEPALIVE,
     "health_check_interval": settings.CELERY_REDIS_HEALTH_CHECK_INTERVAL,
     "retry_on_timeout": settings.CELERY_REDIS_RETRY_ON_TIMEOUT,
+    "socket_timeout": settings.CELERY_REDIS_SOCKET_TIMEOUT,
+    "socket_connect_timeout": settings.CELERY_REDIS_SOCKET_CONNECT_TIMEOUT,
+    "socket_keepalive_options": _socket_keepalive_options,
 }
 
 celery.conf.update(

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from lso.config import settings
 from lso.worker import RUN_EXECUTABLE, RUN_PLAYBOOK, celery
 
 
@@ -42,6 +43,21 @@ def test_celery_broker_is_configured_to_self_heal_after_switch_over() -> None:
     assert transport_options["socket_keepalive"] is True
     assert transport_options["retry_on_timeout"] is True
     assert transport_options["health_check_interval"] > 0
+
+    # A switch-over kills connections without an RST reaching the client; without a socket
+    # timeout, an unbounded recv() on such a half-open socket blocks the consumer restart
+    # forever, before any of the retry settings above can engage.
+    assert transport_options["socket_timeout"] > 0
+    assert transport_options["socket_connect_timeout"] > 0
+    # TCP keep-alive timing must be overridden: the kernel default (7200s idle) means a broker
+    # connection that died silently would go unnoticed for up to 2 hours. Constant names differ
+    # per platform (TCP_KEEPIDLE on Linux, TCP_KEEPALIVE on macOS), so assert on the values.
+    keepalive_options = transport_options["socket_keepalive_options"]
+    assert sorted(keepalive_options.values()) == [
+        settings.CELERY_REDIS_SOCKET_KEEPALIVE_COUNT,
+        settings.CELERY_REDIS_SOCKET_KEEPALIVE_INTERVAL,
+        settings.CELERY_REDIS_SOCKET_KEEPALIVE_IDLE,
+    ]
 
     # The Redis result store ignores transport options for connection parameters; it only honors
     # these top-level redis_* settings.


### PR DESCRIPTION
Follow-up to #210.

When the Redis node behind a virtual IP changes (a switch-over), the worker's broker connections die without the client noticing — no RST is sent. The worker then blocks forever on a socket read, before any of the retry logic from #210 can run. The kernel's default TCP keepalive only kicks in after 2 hours, so the worker stays stuck until someone restarts it.

This adds socket_timeout, socket_connect_timeout and TCP keepalive settings to the broker connection. A dead socket now fails within ~30 seconds and the existing retry logic takes over.

Verified against a live Redis failover (VIP moved to a read-only replica for ~7 minutes, then back to the master):
- workers WITH this change reconnected within seconds of the VIP returning
- a control worker WITHOUT it stayed stuck until manually restarted

Note: TCP_KEEPIDLE doesn't exist on macOS, so the code falls back to TCP_KEEPALIVE there. Only relevant for local development; production deployments are Linux.