### PR TITLE
fix: pin redis-py to kombu's supported range to prevent deaf workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestrator-lso"
-version = "4.2.1"
+version = "4.2.2"
 description = "LSO, an API for remotely running Ansible playbooks."
 readme = "README.md"
 license = "Apache-2.0"
@@ -37,7 +37,10 @@ dependencies = [
     "fastapi==0.141.1",
     "httpx2==2.10.0",
     "pydantic-settings==2.15.0",
-    "redis==8.1.0",
+    # redis-py must stay within kombu's supported range (<6.5). redis-py >=8 silently
+    # reconnects broker sockets without kombu noticing, leaving workers permanently
+    # deaf (no BRPOP/PSUBSCRIBE re-issued) after a Redis connection loss.
+    "redis==5.3.1",
     "requests==2.34.2",
     "uvicorn[standard]==0.52.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-lso"
-version = "4.2.1"
+version = "4.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },
@@ -928,7 +928,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.141.1" },
     { name = "httpx2", specifier = "==2.10.0" },
     { name = "pydantic-settings", specifier = "==2.15.0" },
-    { name = "redis", specifier = "==8.1.0" },
+    { name = "redis", specifier = "==5.3.1" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.52.1" },
 ]
@@ -1164,6 +1164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1311,11 +1320,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "8.1.0"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

This project pins `redis==8.1.0`, but kombu 5.6.2 supports `redis >=4.5.2, <6.5` (declared in its package metadata). The resolver never flags the conflict because `redis` is a direct dependency here rather than coming through `celery[redis]`, so the unsupported combination installs silently.

## Symptom

With redis-py 8, when a worker loses its connection to Redis (network failure or failover), the TCP connection is silently repaired underneath kombu. The worker never re-issues its blocking reads and subscriptions (`BRPOP`/`PSUBSCRIBE`), so it looks connected but permanently stops consuming tasks and answering `inspect ping`. TCP keepalive cannot help: the sockets are alive, just protocol-dead.

## Evidence

Reproduced in a test environment by black-holing worker-to-Redis traffic for 120 seconds:

| redis-py | Result |
|---|---|
| 8.1.0 | Worker wedged on every attempt (2/2): TCP restored, but no `BRPOP`/`PSUBSCRIBE` visible in Redis `CLIENT LIST`, deaf to `inspect ping`, no recovery logging |
| 5.3.1 | Recovered in under 2 seconds: `Connected to redis` -> `mingle: sync complete` -> healthy |

Same container image, same configuration, same fault — only the redis-py version changed.

Related upstream regression class: celery/kombu#2007 — the reason kombu caps its supported redis-py range.

## Why not a newer redis-py

No kombu release supports redis-py 8, so this cannot be fixed by upgrading kombu:

- kombu 5.6.2 (latest release): `redis >=4.5.2, <6.5`
- kombu main branch (unreleased): `redis >=5.3.1, <8.0.0` — still excludes 8.x

`5.3.1` is inside the current supported range and is also the exact floor of kombu main's range, so this pin stays valid for the next kombu release too. redis-py is only used here as celery's broker driver; nothing in this project needs a newer client.

Note: the Redis *server* version is independent of the client library version — redis-py 5.3.1 works fine with modern Redis servers.

## Change

- Pin `redis==5.3.1` with an explanatory comment
- Bump version to 4.2.2

## Testing

- `uv lock` + `uv sync --locked` resolve cleanly; `lso.worker` imports with redis-py 5.3.1
- Live fault-injection A/B test as described above
