### PR TITLE
Fix admonition formatting

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,8 +11,9 @@ However, we recommend you prepare the following files:
 - `compose.yaml` - For deploying your Docker image, explained below
 
 !!! danger "Running LSO securely"
-Be aware that LSO is a tool that allows users to run lots of things, including potentially destructive actions.
-It is important to be aware of your environment where LSO is planned to be running.
+
+    Be aware that LSO is a tool that allows users to run lots of things, including potentially destructive actions.
+    It is important to be aware of your environment where LSO is planned to be running.
 
     **Ensure that there is no public access to this container that runs LSO outside of known-safe users.**
 


### PR DESCRIPTION
This admonition was not formatting correctly due to a whitespace error in docs src

<img width="820" height="331" alt="image" src="https://github.com/user-attachments/assets/0f9ecd52-5a4c-4fdd-b76f-a896c374e74a" />
