### PR TITLE
Add file endpoints to manage job files

### DIFF
--- a/lso/app.py
+++ b/lso/app.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from lso import environment
 from lso.routes.default import router as default_router
 from lso.routes.execute import router as executable_router
+from lso.routes.files import router as files_router
 from lso.routes.playbook import router as playbook_router
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ def create_app() -> FastAPI:
     app.include_router(default_router, prefix="/api")
     app.include_router(playbook_router, prefix="/api/playbook")
     app.include_router(executable_router, prefix="/api/execute")
+    app.include_router(files_router, prefix="/api/files")
 
     environment.setup_logging()
 

--- a/lso/config.py
+++ b/lso/config.py
@@ -36,6 +36,7 @@ class Config(BaseSettings):
         TESTING (bool, optional): `True` if running in a testing environment, `False` otherwise.
         ANSIBLE_PLAYBOOKS_ROOT_DIR (str): Absolute path to the location where Ansible playbooks are stored.
         EXECUTABLES_ROOT_DIR (str): Absolute path to the location where executables are stored.
+        JOB_FILES_ROOT_DIR (str): Absolute path to the location where per-job output files are stored.
         EXECUTOR (ExecutorType, optional): The executor type that LSO uses.
         MAX_THREAD_POOL_WORKERS (int, optional): The amount of threads in the pool, if using the thread pool executor.
         REQUEST_TIMEOUT_SEC (int, optional): HTTP Timeout, in seconds.
@@ -77,6 +78,7 @@ class Config(BaseSettings):
     TESTING: bool = True
     ANSIBLE_PLAYBOOKS_ROOT_DIR: str = "/path/to/ansible/playbooks"
     EXECUTABLES_ROOT_DIR: str = "/path/to/executables"
+    JOB_FILES_ROOT_DIR: str = "/path/to/lso_job_files"
     EXECUTOR: ExecutorType = ExecutorType.THREADPOOL
     MAX_THREAD_POOL_WORKERS: int = min(32, (os.cpu_count() or 1) + 4)
     REQUEST_TIMEOUT_SEC: int = 10

--- a/lso/playbook.py
+++ b/lso/playbook.py
@@ -61,6 +61,8 @@ def run_playbook(
 
     """
     job_id = uuid4()
+    job_files_dir = resolve_within_root(settings.JOB_FILES_ROOT_DIR, Path(str(job_id)))
+    extra_vars = extra_vars | {"job_id": str(job_id), "job_files_dir": str(job_files_dir)}
     callback_str = None
     progress_str = None
     if callback:

--- a/lso/routes/files.py
+++ b/lso/routes/files.py
@@ -53,11 +53,11 @@ def list_files(job_id: UUID) -> JobFilesResponse:
     if not job_dir.is_dir():
         return JobFilesResponse(job_id=job_id, files=[])
 
-    files = sorted(entry.name for entry in job_dir.iterdir() if entry.is_file())
+    files = [entry.relative_to(job_dir).as_posix() for entry in job_dir.rglob("*") if entry.is_file()]
     return JobFilesResponse(job_id=job_id, files=files)
 
 
-@router.get("/{job_id}/{filename}")
+@router.get("/{job_id}/{filename:path}")
 def download_file(job_id: UUID, filename: SafeName) -> FileResponse:
     """Download a single file produced by a job.
 
@@ -65,7 +65,8 @@ def download_file(job_id: UUID, filename: SafeName) -> FileResponse:
         HTTPException: Raises a 404 if the file does not exist.
 
     """
-    file_path = resolve_within_root(settings.JOB_FILES_ROOT_DIR, Path(str(job_id)) / filename)
+    job_dir = _job_dir(job_id)
+    file_path = resolve_within_root(str(job_dir), filename)
     if not file_path.is_file():
         msg = f"File '{filename}' does not exist for job '{job_id}'"
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)

--- a/lso/routes/files.py
+++ b/lso/routes/files.py
@@ -1,0 +1,81 @@
+# Copyright 2023-2026 GÉANT Vereniging.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API endpoints for listing, downloading, and deleting files produced by a job."""
+
+import shutil
+from pathlib import Path
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from lso.config import settings
+from lso.schema import SafeName
+from lso.utils import resolve_within_root
+
+router = APIRouter()
+
+
+class JobFilesResponse(BaseModel):
+    """Response listing the files produced by a job.
+
+    Attributes:
+        job_id (UUID): The job whose files are listed.
+        files (list[str]): Names of the files produced by the job.
+
+    """
+
+    job_id: UUID
+    files: list[str]
+
+
+def _job_dir(job_id: UUID) -> Path:
+    """Resolve the directory holding a job's files, confined to `JOB_FILES_ROOT_DIR`."""
+    return resolve_within_root(settings.JOB_FILES_ROOT_DIR, Path(str(job_id)))
+
+
+@router.get("/{job_id}")
+def list_files(job_id: UUID) -> JobFilesResponse:
+    """List the files produced by a job."""
+    job_dir = _job_dir(job_id)
+    if not job_dir.is_dir():
+        return JobFilesResponse(job_id=job_id, files=[])
+
+    files = sorted(entry.name for entry in job_dir.iterdir() if entry.is_file())
+    return JobFilesResponse(job_id=job_id, files=files)
+
+
+@router.get("/{job_id}/{filename}")
+def download_file(job_id: UUID, filename: SafeName) -> FileResponse:
+    """Download a single file produced by a job.
+
+    Raises:
+        HTTPException: Raises a 404 if the file does not exist.
+
+    """
+    file_path = resolve_within_root(settings.JOB_FILES_ROOT_DIR, Path(str(job_id)) / filename)
+    if not file_path.is_file():
+        msg = f"File '{filename}' does not exist for job '{job_id}'"
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=msg)
+
+    return FileResponse(file_path)
+
+
+@router.delete("/{job_id}/delete", status_code=status.HTTP_204_NO_CONTENT)
+def delete_files(job_id: UUID) -> None:
+    """Delete all files produced by a job."""
+    job_dir = _job_dir(job_id)
+    if job_dir.is_dir():
+        shutil.rmtree(job_dir)

--- a/test/routes/test_files.py
+++ b/test/routes/test_files.py
@@ -36,7 +36,7 @@ def test_list_files_returns_empty_list_for_unknown_job(client: TestClient) -> No
     assert response.json() == {"job_id": str(job_id), "files": []}
 
 
-def test_list_files_returns_files_sorted(client: TestClient, job_files_root: Path) -> None:
+def test_list_files_returns_files(client: TestClient, job_files_root: Path) -> None:
     job_id = uuid4()
     job_dir = job_files_root / str(job_id)
     job_dir.mkdir()
@@ -47,7 +47,20 @@ def test_list_files_returns_files_sorted(client: TestClient, job_files_root: Pat
     response = client.get(f"/api/files/{job_id}")
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"job_id": str(job_id), "files": ["a.txt", "b.txt"]}
+    assert set(response.json()["files"]) == {"a.txt", "b.txt"}
+
+
+def test_list_files_includes_files_in_subdirectories(client: TestClient, job_files_root: Path) -> None:
+    job_id = uuid4()
+    job_dir = job_files_root / str(job_id)
+    (job_dir / "subdir").mkdir(parents=True)
+    (job_dir / "result.txt").write_text("top-level")
+    (job_dir / "subdir" / "nested.txt").write_text("nested")
+
+    response = client.get(f"/api/files/{job_id}")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert set(response.json()["files"]) == {"result.txt", "subdir/nested.txt"}
 
 
 def test_download_file_returns_content(client: TestClient, job_files_root: Path) -> None:
@@ -60,6 +73,29 @@ def test_download_file_returns_content(client: TestClient, job_files_root: Path)
 
     assert response.status_code == status.HTTP_200_OK
     assert response.text == "done\n"
+
+
+def test_download_file_in_subdirectory_returns_content(client: TestClient, job_files_root: Path) -> None:
+    job_id = uuid4()
+    job_dir = job_files_root / str(job_id)
+    (job_dir / "subdir").mkdir(parents=True)
+    (job_dir / "subdir" / "nested.txt").write_text("nested\n")
+
+    response = client.get(f"/api/files/{job_id}/subdir/nested.txt")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.text == "nested\n"
+
+
+def test_download_file_rejects_escape_into_root_dir(client, job_files_root: Path) -> None:
+    job_id = uuid4()
+    root_dir = job_files_root
+    (root_dir / "secret.txt").write_text("not yours\n")
+
+    response = client.get(f"/api/files/{job_id}/..%2Fsecret.txt")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"detail": "Path '../secret.txt' is outside the configured root directory."}
 
 
 def test_download_file_missing_returns_404(client: TestClient) -> None:

--- a/test/routes/test_files.py
+++ b/test/routes/test_files.py
@@ -1,0 +1,94 @@
+# Copyright 2023-2026 GÉANT Vereniging.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from lso.config import settings
+
+
+@pytest.fixture(autouse=True)
+def job_files_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Confine `JOB_FILES_ROOT_DIR` to a fresh directory for every test in this module."""
+    monkeypatch.setattr(settings, "JOB_FILES_ROOT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_list_files_returns_empty_list_for_unknown_job(client: TestClient) -> None:
+    job_id = uuid4()
+
+    response = client.get(f"/api/files/{job_id}")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"job_id": str(job_id), "files": []}
+
+
+def test_list_files_returns_files_sorted(client: TestClient, job_files_root: Path) -> None:
+    job_id = uuid4()
+    job_dir = job_files_root / str(job_id)
+    job_dir.mkdir()
+    (job_dir / "b.txt").write_text("second")
+    (job_dir / "a.txt").write_text("first")
+    (job_dir / "subdir").mkdir()
+
+    response = client.get(f"/api/files/{job_id}")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"job_id": str(job_id), "files": ["a.txt", "b.txt"]}
+
+
+def test_download_file_returns_content(client: TestClient, job_files_root: Path) -> None:
+    job_id = uuid4()
+    job_dir = job_files_root / str(job_id)
+    job_dir.mkdir()
+    (job_dir / "result.txt").write_text("done\n")
+
+    response = client.get(f"/api/files/{job_id}/result.txt")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.text == "done\n"
+
+
+def test_download_file_missing_returns_404(client: TestClient) -> None:
+    job_id = uuid4()
+
+    response = client.get(f"/api/files/{job_id}/does-not-exist.txt")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": f"File 'does-not-exist.txt' does not exist for job '{job_id}'"}
+
+
+def test_delete_files_removes_job_dir(client: TestClient, job_files_root: Path) -> None:
+    job_id = uuid4()
+    job_dir = job_files_root / str(job_id)
+    job_dir.mkdir()
+    (job_dir / "result.txt").write_text("data")
+
+    response = client.delete(f"/api/files/{job_id}/delete")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not job_dir.exists()
+
+    listing = client.get(f"/api/files/{job_id}")
+    assert listing.json() == {"job_id": str(job_id), "files": []}
+
+
+def test_delete_files_is_a_noop_for_unknown_job(client: TestClient) -> None:
+    job_id = uuid4()
+
+    response = client.delete(f"/api/files/{job_id}/delete")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.12, <3.15"
 
+[options]
+prerelease-mode = "if-necessary"
+
 [[package]]
 name = "amqp"
 version = "5.3.1"


### PR DESCRIPTION

endpoints:
 - GET `api/files/{job_id}` list files for the job id
 - GET `api/files/{job_id}/{file_name}` to get a file for the job id
 - DELETE `api/files/{job_id}`to delete all files for the job id

add config `JOB_FILES_ROOT_DIR` to set the path where the files should be stored and it is added with the job_id into the extra_vars to use in playbooks.

Closes: https://github.com/workfloworchestrator/lso/issues/179